### PR TITLE
Add GenCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _Last updated: 2026-02-11 01:54 UTC_
 - [fauxpilot/fauxpilot](https://github.com/fauxpilot/fauxpilot) - FauxPilot - an open-source alternative to GitHub Copilot server [Copilot] (14k⭐)
 - [github/copilot.vim](https://github.com/github/copilot.vim) - Neovim plugin for GitHub Copilot [Copilot] (11k⭐)
 - [opencode-ai/opencode](https://github.com/opencode-ai/opencode) - A powerful AI coding agent. Built for the terminal. [Terminal] (10k⭐)
+- [yanmxa/gencode](https://github.com/yanmxa/gencode) - Open-source AI coding assistant for the terminal. Multi-provider support, flexible context management, compatible with Claude Code extensions and plugins. [Terminal]
 - [HugoBlox/kit](https://github.com/HugoBlox/kit) - ⚡ The Open Research Copilot. Build high-perf Portfolios, Lab Sites & Docs in Markdown + Jupyter. 100% Data Control. 🦫 数据科学家的开源 Copilot。一键部署 👇 [Copilot] (9k⭐)
 - [zoicware/RemoveWindowsAI](https://github.com/zoicware/RemoveWindowsAI) - Force Remove Copilot, Recall and More in Windows 11 [Copilot] (9k⭐)
 - [microsoft/vscode-copilot-chat](https://github.com/microsoft/vscode-copilot-chat) - Copilot Chat extension for VS Code [Copilot] (9k⭐)


### PR DESCRIPTION
## Summary

Add [GenCode](https://github.com/yanmxa/gencode) to the Terminal tools list.

GenCode is an open-source AI coding assistant for the terminal with multi-provider support (Anthropic, OpenAI, Gemini, Moonshot), flexible context management, and Claude Code extension compatibility. Written in Go, Apache 2.0 licensed.