### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ _Last updated: 2026-07-08 02:07 UTC_
 - [YishenTu/claudian](https://github.com/YishenTu/claudian) - An Obsidian plugin that embeds Claude Code/Codex as an AI collaborator in your vault [Vim/Neovim] (13k⭐)
 - [superset-sh/superset](https://github.com/superset-sh/superset) - Code Editor for the AI Agents Era - Run an army of Claude Code, Codex, etc. on your machine [Terminal] (12k⭐)
 - [rohitg00/agentmemory](https://github.com/rohitg00/agentmemory) - #1 Persistent memory for AI coding agents based on real-world benchmarks [Copilot] (24k⭐)
+- [TerminallyLazy/Tree-Ring-Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) - Framework-agnostic, local-first memory lifecycle for AI agents: Rust CLI, SQLite/FTS recall, forgetting, audit, consolidation, DOX/Revolve adapters, and TUI. [Terminal] (5⭐)
 - [1jehuang/jcode](https://github.com/1jehuang/jcode) - Coding Agent Harness [Terminal] (8k⭐)
 - [github/copilot-cli](https://github.com/github/copilot-cli) - GitHub Copilot CLI brings the power of Copilot coding agent directly to your terminal. [Terminal] (10k⭐)
 - [CoplayDev/unity-mcp](https://github.com/CoplayDev/unity-mcp) - Unity MCP acts as a bridge between AI assistants and your Unity Editor. Give your LLM tools to manage assets, control scenes, edit scripts, and automate tasks within Unity. [Copilot] (12k⭐)


### PR DESCRIPTION
## Summary

- Add `TerminallyLazy/Tree-Ring-Memory` as a terminal AI-agent memory tool.
- Uses the existing generated README entry format so the crawler can parse the row as an existing repository on future runs.

## Checks

- `git diff --check`
- Verified the crawler README regex parses `TerminallyLazy/Tree-Ring-Memory` with tag `Terminal`.

