### PR TITLE
Add Atomic Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ _Last updated: 2026-08-13 01:23 UTC_
 - [agent-of-empires/agent-of-empires](https://github.com/agent-of-empires/agent-of-empires) - Manage multiple Claude Code, OpenCode agents from either TUI or Web for easy access on mobile. Also supports Mistral Vibe, Codex CLI, Gemini CLI, Pi.dev, Copilot CLI, Factory Droid Coding. [Terminal] (3k⭐)
 - [generalaction/emdash](https://github.com/generalaction/emdash) - Emdash is the Open-Source Agentic Development Environment (🧡 YC W26). Run multiple coding agents in parallel. Use any provider. [Terminal] (5k⭐)
 - [getkimchi/kimchi](https://github.com/getkimchi/kimchi) - Terminal coding agent powered by Kimchi's multi-model orchestration [Terminal] (2k⭐)
+- [AtomicBot-ai/atomic-agent](https://github.com/AtomicBot-ai/atomic-agent) - Local-first CLI and TUI coding agent. Runs open-weight models entirely on your machine, with no account or API key required. 56 built-in tools and MCP support. [Terminal] (1k⭐)
 - [plandex-ai/plandex](https://github.com/plandex-ai/plandex) - Open source AI coding agent. Designed for large projects and real world tasks. [Terminal] (15k⭐)
 - [gptme/gptme](https://github.com/gptme/gptme) - Your agent in your terminal, equipped with local tools: writes code, uses the terminal, browses the web. Make your own persistent autonomous agent on top! [Terminal] (4k⭐)
 - [WordPress/agent-skills](https://github.com/WordPress/agent-skills) - Expert-level WordPress knowledge for AI coding assistants - blocks, themes, plugins, and best practices [Vim/Neovim] (2k⭐)


### PR DESCRIPTION
Hi! I'm the CPO of Atomic Agent. Thanks for keeping this list, it's one of the few that stays focused on tools you actually run in a terminal rather than every AI project on GitHub. Our team would be thrilled to be included.

## What it is

[Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) is a local-first CLI and TUI coding agent (the TUI is React + ink). It runs open-weight models entirely on your machine through a llama.cpp fork, so there's no account or API key required to install and run it. It ships 56 built-in tools (browser, filesystem, git, memory, vision), supports MCP, has a five-layer local memory system, and runs on macOS, Linux, and Windows. MIT licensed, ~2k stars, actively maintained.

```
curl -fsSL https://atomicagent.io/install | sh
```

Site: https://atomicagent.io · Docs: https://atomicagent.io/docs · Discord: https://discord.gg/Us7qXtDGw · X: https://x.com/atomicagent_io

## About the crawler

I noticed the list body is generated by `scripts/crawler.py` between the `AUTO-GENERATED` markers, so I want to be upfront about how this edit interacts with it rather than just dropping a line in.

I checked our repo against the current `Terminal` query (`agentic coding terminal stars:>100`) and we are **not** in its top 30 results, so the crawler would not add us on its own. I also ran your `parse_existing_repos()` against the edited README to confirm this isn't a line that silently disappears tomorrow: the row matches your parser's regex, gets picked up as an existing entry, and is preserved through `merge_and_sort_repos()`. We're not in `block-list.txt` either.

One thing worth flagging: `merge_and_sort_repos()` re-fetches each existing entry and overwrites the description with the live GitHub one, so the wording I've written here will be replaced by our repo description on the next nightly run, and the row will re-sort by `updated_at`. That's your pipeline working as intended, and it's fine by us. I've kept the row in your exact format (`- [owner/repo](url) - description [Tag] (stars⭐)`) with the `[Terminal]` tag and the `1k⭐` string your `format_star_count()` produces for our current star count, so the entry stays consistent with everything the crawler generates.

Happy to adjust the wording, the tag, or the placement, or to drop the manual row entirely if you'd rather widen the crawler query instead. Whatever fits how you want to maintain the list.
