### PR TITLE
Add kolega-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,5 @@ _Last updated: 2026-08-21 00:57 UTC_
 - [lxf746/any-auto-register](https://github.com/lxf746/any-auto-register) - Auto-register & manage accounts for ChatGPT, Cursor, Kiro, Grok, Windsurf, Trae & 13+ AI platforms · Protocol/browser dual-mode · Plugin-based · One-click Mac/Windows desktop app [Vim/Neovim] (3k⭐)
 - [twinnydotdev/twinny](https://github.com/twinnydotdev/twinny) - The most no-nonsense, locally or API-hosted AI code completion plugin for Visual Studio Code - like GitHub Copilot but 100% free. [Vim/Neovim] (3k⭐)
 - [zombieyang/sd-ppp](https://github.com/zombieyang/sd-ppp) - A Photoshop AI plugin [Vim/Neovim] (2k⭐)
+- [kolega-ai/kolega-code](https://github.com/kolega-ai/kolega-code) - Terminal coding agent where the model writes its own multi-agent workflows (Gigacode). [Terminal] (15⭐)
 <!-- AUTO-GENERATED-END -->

--- a/README.md
+++ b/README.md
@@ -60,4 +60,5 @@ _Last updated: 2026-08-25 00:55 UTC_
 - [getkimchi/kimchi](https://github.com/getkimchi/kimchi) - Terminal coding agent powered by Kimchi's multi-model orchestration [Terminal] (2k⭐)
 - [zombieyang/sd-ppp](https://github.com/zombieyang/sd-ppp) - A Photoshop AI plugin [Vim/Neovim] (2k⭐)
 - [WordPress/agent-skills](https://github.com/WordPress/agent-skills) - Expert-level WordPress knowledge for AI coding assistants - blocks, themes, plugins, and best practices [Vim/Neovim] (2k⭐)
+- [kolega-ai/kolega-code](https://github.com/kolega-ai/kolega-code) - Terminal coding agent where the model writes its own multi-agent workflows (Gigacode). [Terminal] (15⭐)
 <!-- AUTO-GENERATED-END -->


### PR DESCRIPTION
# Add kolega-code

Adds kolega-ai/kolega-code to the Terminal section of the list.

Kolega Code is a terminal coding agent where the model writes its own multi-agent workflows (Gigacode). The entry uses the same `- [owner/repo](url) - description [Terminal] (stars)` format the daily crawler parses, so it will survive regeneration and get its description and stars refreshed automatically.
